### PR TITLE
Add error checks for 3D local conductivity (kappa) calculation

### DIFF
--- a/code/make/txt/mesh/sandstone_3062_grains.mk
+++ b/code/make/txt/mesh/sandstone_3062_grains.mk
@@ -40,7 +40,7 @@ build/$(MODE)/txt/mesh/sandstone_3062_grains_kappa.txt:\
   assets/mesh/sandstone_3062_grains_vpore.csv\
   assets/mesh/sandstone_3062_grains_fpore.csv\
   | build/$(MODE)/txt/mesh
-	$(INTERPRETER) $< --raw $(word 2, $^) $(word 3, $^) $(word 4, $^) $(word 5, $^) $(word 6, $^) 0.0651 > $@
+	$(INTERPRETER) $< --raw $(word 2, $^) $(word 3, $^) $(word 4, $^) $(word 5, $^) $(word 6, $^) 0.0651 74 6526 > $@
 
 build/$(MODE)/txt/mesh/sandstone_3062_grains_forman.txt:\
   build/$(MODE)/bin/forman_boundary$(.EXE)\


### PR DESCRIPTION
1. Add error checks.
2. Fixed a mistake when allocating kappa1 (each edge to nodes) -- 2k-1 -> 2i+1.